### PR TITLE
prod-flatcar/: restart systemd-sysext only on demand

### DIFF
--- a/prod-flatcar/wasmtime.json
+++ b/prod-flatcar/wasmtime.json
@@ -29,14 +29,24 @@
   "systemd": {
     "units": [
       {
-        "contents": "[Unit]\nDescription=wasmtime sysupdate checker\n[Service]\nRestart=no\nType=oneshot\nExecStart=/usr/lib/systemd/systemd-sysupdate -C wasmtime update\nExecStartPost=systemctl restart systemd-sysext\n",
+        "contents": "[Unit]\nDescription=wasmtime sysupdate checker\n[Service]\nRestart=no\nType=oneshot\nExecStart=/usr/lib/systemd/systemd-sysupdate -C wasmtime update\n",
         "enabled": false,
         "name": "sysext-wasmtime-update-check.service"
       },
       {
-        "contents": "[Unit]\nDescription=wasmtime sysupdate checker timer\n[Timer]\nOnCalendar=*-*-* *:*:00\nPersistent=true\n[Install]\nWantedBy=timers.target",
+        "contents": "[Unit]\nDescription=wasmtime sysupdate checker timer\n[Timer]\nOnCalendar=*-*-* *:*:00\nPersistent=true\n[Install]\nWantedBy=timers.target\n",
         "enabled": true,
         "name": "sysext-wasmtime-update-check.timer"
+      },
+      {
+        "contents": "[Unit]\nDescription=Trigger a restart of systemd-sysext to auto-merge new / updated extensions.\n[Path]\nPathModified=/etc/extensions\nUnit=sysext-restart.service\n[Install]\nWantedBy=paths.target\n",
+        "enabled": true,
+        "name": "sysext-update-watcher.path"
+      },
+      {
+        "contents": "[Unit]\nDescription=Restart systemd-sysext, e.g. to merge new / updated sysexts.               \n[Service]\nRestart=no\nType=oneshot\nExecStart=systemctl restart systemd-sysext\n",
+        "enabled": false,
+        "name": "sysext-restart.service"
       }
     ]
   }

--- a/prod-flatcar/wasmtime.yaml
+++ b/prod-flatcar/wasmtime.yaml
@@ -43,7 +43,6 @@ systemd:
         Restart=no
         Type=oneshot
         ExecStart=/usr/lib/systemd/systemd-sysupdate -C wasmtime update
-        ExecStartPost=systemctl restart systemd-sysext
 
     - name: sysext-wasmtime-update-check.timer
       enabled: true
@@ -56,3 +55,24 @@ systemd:
         Persistent=true
         [Install]
         WantedBy=timers.target
+
+    - name: sysext-update-watcher.path                                                   
+      enabled: true
+      contents: |                                                                        
+        [Unit]
+        Description=Trigger a restart of systemd-sysext to auto-merge new / updated extensions.
+        [Path]
+        PathModified=/etc/extensions
+        Unit=sysext-restart.service
+        [Install]
+        WantedBy=paths.target
+
+    - name: sysext-restart.service
+      enabled: false
+      contents: |
+        [Unit]
+        Description=Restart systemd-sysext, e.g. to merge new / updated sysexts.               
+        [Service]
+        Restart=no
+        Type=oneshot
+        ExecStart=systemctl restart systemd-sysext


### PR DESCRIPTION
This PR introduces a systemd [path unit](https://www.freedesktop.org/software/systemd/man/systemd.path.html) for watching `/etc/extensions` and a corresponding service unit that restarts `systemd-sysext.service` on demand, i.e. if any changes happened in the directory watched.

The unconditional systemd-sysext restart in `sysext-wasmtime-update-check.service` is removed.

This fixes a potential issue with sysext restart: currently, systemd-sysext is restarted on every update _check_, even if no sysext was updated. Since the update check timer is currently set to one minute, this results in all sysexts being remounted each minute.

Most notably, the syslog / dmesg log is spammed with
```
[    7.256916] loop1: detected capacity change from 0 to 20984
[    7.321305] loop2: detected capacity change from 0 to 8
[    7.324484] loop3: detected capacity change from 0 to 20984
[    8.421751] loop4: detected capacity change from 0 to 8
[    8.468260] loop5: detected capacity change from 0 to 20984
[    8.528903] loop6: detected capacity change from 0 to 8
[    8.532132] loop7: detected capacity change from 0 to 20984
[   74.062088] loop0: detected capacity change from 0 to 20984
[   74.123929] loop0: detected capacity change from 0 to 8
[   74.158010] loop0: detected capacity change from 0 to 20984
[   74.163746] loop1: detected capacity change from 0 to 8
[  134.607471] loop4: detected capacity change from 0 to 8
[  134.648609] loop4: detected capacity change from 0 to 20984
[  134.690328] loop4: detected capacity change from 0 to 8
[  134.700228] loop5: detected capacity change from 0 to 20984
[  204.641353] loop0: detected capacity change from 0 to 8
[  205.051299] loop1: detected capacity change from 0 to 20984
[  205.602295] loop0: detected capacity change from 0 to 8
[  205.606284] loop1: detected capacity change from 0 to 20984
[  266.584347] loop4: detected capacity change from 0 to 8
[  266.617455] loop5: detected capacity change from 0 to 20984
[  266.652368] loop4: detected capacity change from 0 to 8
[  266.656419] loop5: detected capacity change from 0 to 20984
[  310.492818] loop8: detected capacity change from 0 to 8
[  310.533881] loop8: detected capacity change from 0 to 20984
[  310.576891] loop8: detected capacity change from 0 to 8
[  310.583227] loop9: detected capacity change from 0 to 20984
[  404.542006] loop10: detected capacity change from 0 to 20984
[  404.585131] loop10: detected capacity change from 0 to 8
[  404.649088] loop10: detected capacity change from 0 to 20984
[  404.691858] loop11: detected capacity change from 0 to 8
```

The change in this PR only restarts sysext on demand, i.e. only when a sysext really was added or updated in `/etc/extensions`.